### PR TITLE
feat: add Link component with styles and props

### DIFF
--- a/assets/scss/index.scss
+++ b/assets/scss/index.scss
@@ -47,6 +47,8 @@
 
 @use "../../components/Inline/inline.styles.scss" as *;
 
+@use "../../components/Link/link.styles.scss" as *;
+
 * {
   @apply font-montserrat;
 }

--- a/components/Link/Link.vue
+++ b/components/Link/Link.vue
@@ -1,0 +1,58 @@
+<template>
+  <a
+    :class="linkKls"
+    :href="disabled || !href ? undefined : href"
+    :target="disabled || !href ? undefined : target"
+    @click="handleClick"
+  >
+    <!-- Left Icon -->
+    <g-icon-font 
+      v-if="iconLeft" 
+      :name="iconLeft" 
+      :class="ns.e('icon-left')"
+    />
+    
+    <!-- Content / Text -->
+    <span :class="ns.e('inner')">
+      <slot />
+    </span>
+    
+    <!-- Right Icon -->
+    <g-icon-font 
+      v-if="iconRight" 
+      :name="iconRight" 
+      :class="ns.e('icon-right')"
+    />
+
+    <!-- Custom Icon Slot -->
+    <slot v-if="$slots.icon" name="icon" />
+  </a>
+</template>
+
+<script lang="ts" setup>
+import { computed } from 'vue'
+import { GIconFont } from "@flash-global66/b2b-ui-icon-font";
+import { useNamespace } from "element-plus";
+import { linkEmits, linkProps } from './link'
+
+defineOptions({
+  name: 'GLink',
+})
+const props = defineProps(linkProps)
+const emit = defineEmits(linkEmits)
+
+const ns = useNamespace('link')
+
+const linkKls = computed(() => [
+  ns.b(),
+  ns.m(props.type),
+  ns.m(props.size),
+  ns.m(props.status),
+  ns.is('disabled', props.disabled),
+  ns.is('underline', props.underline && !props.disabled),
+])
+
+function handleClick(event: MouseEvent) {
+  if (!props.disabled) emit('click', event)
+}
+</script>

--- a/components/Link/index.ts
+++ b/components/Link/index.ts
@@ -1,0 +1,11 @@
+/**
+ * Link Component
+ * Derived from Element Plus v2.9.5
+ * https://github.com/element-plus/element-plus/tree/2.9.5/packages/components/link
+ */
+import Link from './Link.vue'
+
+export { Link as GLink }
+export * from './link'
+
+

--- a/components/Link/link.styles.scss
+++ b/components/Link/link.styles.scss
@@ -1,0 +1,188 @@
+@use 'sass:map';
+
+@use 'element-plus/theme-chalk/src/mixins/mixins' as *;
+@use 'element-plus/theme-chalk/src/mixins/utils' as *;
+@use 'element-plus/theme-chalk/src/mixins/var' as *;
+@use 'element-plus/theme-chalk/src/common/var' as *;
+
+@include b(link) {
+    @apply inline-flex flex-row items-center justify-center;
+    @apply relative no-underline outline-none;
+    @apply cursor-pointer p-0;
+    @apply font-semibold;
+
+    /* Size variations */
+    &.#{$namespace}-link--sm {
+        @apply text-2;
+        
+        @include e(icon-left); @include e(icon-right) {
+            @apply text-3;
+        }
+    }
+
+    &.#{$namespace}-link--md {
+        @apply text-3;
+        
+        @include e(icon-left); @include e(icon-right) {
+            @apply text-3;
+        }
+    }
+
+    &.#{$namespace}-link--lg {
+        @apply text-4;
+        
+        @include e(icon-left); @include e(icon-right) {
+            @apply text-7;
+        }
+    }
+
+    &:hover {
+        @apply text-primary-def-hover;
+    }
+
+    &:active {
+        @apply text-primary-def-press;
+    }
+
+    // Only add underline on hover when NOT already of type "underline"
+    &:not(.#{$namespace}-link--underline) {
+        @include when(underline) {
+            &:hover:after {
+                content: '';
+                @apply absolute left-0 right-0 h-0 bottom-0;
+                @apply border-b border-primary-def-hover;
+            }
+        }
+    }
+
+    @include when(disabled) {
+        @apply text-disabled-txt cursor-not-allowed;
+    }
+
+    @include e('icon-left') {
+        @apply flex items-center justify-center mr-xxs;
+    }
+
+    @include e('icon-right') {
+        @apply flex items-center justify-center ml-xxs;
+    }
+
+    @include e('inner') {
+        @apply inline-flex justify-center items-center;
+    }
+
+    /* Status variations - Define default behavior first */
+    &.#{$namespace}-link--default {
+        @apply text-primary-txt;
+        
+        &:hover {
+            @apply text-primary-def-hover;
+        }
+        
+        &:active {
+            @apply text-primary-def-press;
+        }
+
+        /* Types override base colors but keep status behavior */
+        &.#{$namespace}-link--primary {
+            @apply text-primary-def;
+            
+            &:hover {
+                @apply text-primary-def-hover;
+            }
+            
+            &:active {
+                @apply text-primary-def-press;
+            }
+        }
+
+        &.#{$namespace}-link--success {
+            @apply text-success-def;
+            
+            &:hover {
+                @apply text-success-txt;
+            }
+        }
+
+        &.#{$namespace}-link--warning {
+            @apply text-warning-def;
+            
+            &:hover {
+                @apply text-warning-txt;
+            }
+        }
+
+        &.#{$namespace}-link--danger {
+            @apply text-error-def;
+            
+            &:hover {
+                @apply text-error-txt;
+            }
+        }
+
+        &.#{$namespace}-link--info {
+            @apply text-info-def;
+            
+            &:hover {
+                @apply text-info-txt;
+            }
+        }
+    }
+    
+    /* Inline status - For links within text */
+    &.#{$namespace}-link--inline {
+        @apply text-secondary-txt;
+        
+        &:hover {
+            @apply text-grey-400;
+        }
+        
+        &:active {
+            @apply text-grey-600;
+        }
+        
+        /* For inline links, different underline style */
+        &:not(.#{$namespace}-link--underline) {
+            @include when(underline) {
+                &:hover:after {
+                    @apply border-grey-400;
+                }
+            }
+        }
+    }
+
+    /* Type-specific styles for underline type */  
+    &.#{$namespace}-link--underline {
+        position: relative;
+        
+        &:after {
+            content: '';
+            @apply absolute left-0 right-0 h-0 bottom-0;
+            @apply border-b border-primary-bd;
+        }
+        
+        &:hover {
+            @apply text-primary-def-hover;
+            
+            &:after {
+                @apply border-primary-def-hover;
+            }
+        }
+        
+        &:active {
+            @apply text-primary-def-press;
+            
+            &:after {
+                @apply border-primary-def-press;
+            }
+        }
+        
+        @include when(disabled) {
+            @apply text-disabled-txt;
+            
+            &:after {
+                @apply border-disabled-bd;
+            }
+        }
+    }
+}

--- a/components/Link/link.ts
+++ b/components/Link/link.ts
@@ -1,0 +1,82 @@
+import type { ExtractPropTypes, PropType } from 'vue'
+import { buildProps } from "element-plus/es/utils/index";
+import type { IconString } from "@flash-global66/b2b-ui-icon-font";
+import type Link from './Link.vue'
+
+export const linkProps = buildProps({
+  /**
+   * @description type of link, controls the color scheme
+   */
+  type: {
+    type: String,
+    values: ["default", "underline", "primary", "success", "warning", "info", "danger"],
+    default: "default",
+  },
+  /**
+   * @description size of link
+   */
+  size: {
+    type: String,
+    values: ["sm", "md", "lg"],
+    default: "md",
+  },
+  /**
+   * @description whether the component has underline on hover
+   * Note: Does not apply when type="underline" to prevent double underlines
+   */
+  underline: {
+    type: Boolean,
+    default: true,
+  },
+  /**
+   * @description whether the component is disabled
+   */
+  disabled: Boolean,
+  /**
+   * @description same as native hyperlink's `href`
+   */
+  href: { type: String, default: "" },
+  /**
+   * @description same as native hyperlink's `target`
+   */
+  target: {
+    type: String as PropType<"_blank" | "_parent" | "_self" | "_top" | string>,
+    default: "_self",
+  },
+  /**
+   * @description left icon name for the link
+   */
+  iconLeft: {
+    type: String as PropType<IconString>,
+    default: "",
+  },
+  /**
+   * @description right icon name for the link
+   */
+  iconRight: {
+    type: String as PropType<IconString>,
+    default: "",
+  },
+  /**
+   * @description status of the link, controls contextual appearance
+   * - default: Standalone link with standard styling
+   * - inline: Link designed to be embedded within text paragraphs
+   * 
+   * Note: Use inline status for links that appear within paragraphs of text
+   */
+  status: {
+    type: String,
+    values: ["default", "inline"],
+    default: "default",
+  },
+} as const);
+export type LinkProps = ExtractPropTypes<typeof linkProps>
+
+export const linkEmits = {
+  click: (evt: MouseEvent) => evt instanceof MouseEvent,
+}
+export type LinkEmits = typeof linkEmits
+
+export type LinkInstance = InstanceType<typeof Link>
+
+

--- a/stories/Link.stories.ts
+++ b/stories/Link.stories.ts
@@ -1,0 +1,478 @@
+import { Meta, StoryObj } from '@storybook/vue3';
+import { GLink } from '../components/Link';
+import { LinkProps } from '../components/Link/link';
+import { GConfigProvider } from '../components/ConfigProvider';
+
+const meta: Meta<typeof GLink> = {
+  title: 'Basic/Link',
+  component: GLink,
+  tags: ['autodocs'],
+  argTypes: {
+    type: {
+      control: { type: 'select' },
+      options: ['default', 'underline', 'primary', 'success', 'warning', 'danger', 'info'],
+      description: 'Tipo de estilo del link. Define la apariencia visual y el color del link.',
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: 'default' },
+      },
+    },
+    size: {
+      control: { type: 'select' },
+      options: ['sm', 'md', 'lg'],
+      description: 'Tamaño del link. Afecta tanto al tamaño del texto como de los íconos.',
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: 'md' },
+      },
+    },
+    underline: {
+      control: { type: 'boolean' },
+      description: 'Define si el link muestra un subrayado al pasar el cursor por encima. No aplica cuando el tipo es "underline" para evitar duplicidad.',
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: 'true' },
+      },
+    },
+    disabled: {
+      control: { type: 'boolean' },
+      description: 'Deshabilita el link, impidiendo la interacción del usuario y aplicando estilos visuales de deshabilitado.',
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: 'false' },
+      },
+    },
+    href: {
+      control: { type: 'text' },
+      description: 'URL a la que apunta el link, igual que el atributo href nativo de HTML.',
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: '' },
+      },
+    },
+    target: {
+      control: { type: 'select' },
+      options: ['_blank', '_self', '_parent', '_top'],
+      description: 'Define cómo se abre el link, igual que el atributo target nativo de HTML.',
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: '_self' },
+      },
+    },
+    iconLeft: {
+      control: { type: 'text' },
+      description: 'Nombre del ícono a mostrar a la izquierda del texto. Utiliza el formato "peso nombre-del-icono" (ej: "regular chevron-left").',
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: '' },
+      },
+    },
+    iconRight: {
+      control: { type: 'text' },
+      description: 'Nombre del ícono a mostrar a la derecha del texto. Utiliza el formato "peso nombre-del-icono" (ej: "regular chevron-right").',
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: '' },
+      },
+    },
+    status: {
+      control: { type: 'select' },
+      options: ['default', 'inline'],
+      description: 'Status del link: default (link independiente) o inline (para texto con enlaces).',
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: 'default' },
+      },
+    },
+    onClick: { action: 'clicked' },
+  },
+  parameters: {
+    docs: {
+      description: {
+        component: `
+# Link Component
+
+El componente Link proporciona un link versátil y personalizable para la navegación y acciones:
+
+## Características
+- Múltiples tipos de link (default, underline, primary, success, warning, danger, info)
+- Tres tamaños disponibles: small (sm), medium (md) y large (lg)
+- Soporte para íconos a la izquierda y derecha
+- Estados de hover, active y disabled
+- Compatible con atributos nativos de links HTML
+
+## Instalación
+
+\`\`\`bash
+yarn add @flash-global66/b2b-ui-link
+\`\`\`
+
+## Dependencias
+Este componente requiere:
+- @flash-global66/b2b-ui-icon-font
+
+## Importación de estilos SASS
+Para que el componente funcione correctamente, es necesario importar los estilos SASS:
+
+\`\`\`scss
+@use "@flash-global66/b2b-ui-link/link.styles.scss" as *;
+\`\`\`
+
+## Uso básico
+
+\`\`\`html
+<template>
+  <g-link href="https://empresas.global66.com/">link básico</g-link>
+  
+  <g-link 
+    type="primary"
+    icon-right="regular chevron-right"
+    href="https://empresas.global66.com/"
+    target="_blank"
+  >
+    link con icono
+  </g-link>
+</template>
+
+<script setup>
+import { GLink } from '@flash-global66/b2b-ui-link';
+</script>
+\`\`\`
+`
+      }
+    }
+  },
+  args: {
+    type: 'default',
+    size: 'md',
+    underline: true,
+    disabled: false,
+    href: 'https://empresas.global66.com/',
+    target: '_blank',
+    iconLeft: undefined,
+    iconRight: undefined,
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof GLink>;
+
+export const Default: Story = {
+  name: 'Default link',
+  args: {
+    default: 'default link',
+  },
+  render: (args) => ({
+    components: { GLink, GConfigProvider },
+    setup() {
+      return { args };
+    },
+    template: `
+      <g-config-provider>
+        <g-link v-bind="args">{{ args.default }}</g-link>
+      </g-config-provider>
+    `,
+  }),
+  parameters: {
+    docs: {
+      description: {
+        story: "link básico con estilo por defecto y configuración estándar."
+      },
+      source: {
+        code: `
+<g-link href="https://empresas.global66.com/">link por defecto</g-link>`,
+        language: "html",
+        type: "auto",
+      },
+    },
+  },
+};
+
+export const WithIcons: Story = {
+  name: 'Links con íconos',
+  render: () => ({
+    components: { GLink, GConfigProvider },
+    template: `
+      <g-config-provider>
+        <div class="flex flex-col space-y-4">
+          <div>
+            <h3 class="mb-2 font-semibold">Link with right icon</h3>
+            <g-link href="https://empresas.global66.com/" icon-right="regular chevron-right">Next page</g-link>
+          </div>
+          
+          <div>
+            <h3 class="mb-2 font-semibold">Link with left icon</h3>
+            <g-link href="https://empresas.global66.com/" icon-left="regular chevron-left">Previous page</g-link>
+          </div>
+          
+          <div>
+            <h3 class="mb-2 font-semibold">Link with both icons</h3>
+            <g-link href="https://empresas.global66.com/" icon-left="regular link" icon-right="regular arrow-up-right-from-square">External link</g-link>
+          </div>
+        </div>
+      </g-config-provider>
+    `,
+  }),
+  parameters: {
+    docs: {
+      description: {
+        story: "links con íconos a la izquierda, derecha o ambos lados para mejorar el contexto visual."
+      },
+      source: {
+        code: `
+<g-link href="https://empresas.global66.com/" icon-right="regular chevron-right">
+  link con ícono a la derecha
+</g-link>
+
+<g-link href="https://empresas.global66.com/" icon-left="regular chevron-left">
+  link con ícono a la izquierda
+</g-link>
+
+<g-link href="https://empresas.global66.com/" icon-left="regular link" icon-right="regular arrow-up-right-from-square">
+  link con íconos en ambos lados
+</g-link>`,
+        language: "html",
+        type: "auto",
+      },
+    },
+  },
+};
+
+export const Sizes: Story = {
+  name: 'Tamaños de link',
+  render: () => ({
+    components: { GLink, GConfigProvider },
+    template: `
+      <g-config-provider>
+        <div class="flex flex-col space-y-4">
+          <div>
+            <h3 class="mb-2 font-semibold">Small</h3>
+            <g-link size="sm" href="https://empresas.global66.com/" icon-right="regular chevron-right">Small link</g-link>
+          </div>
+          
+          <div>
+            <h3 class="mb-2 font-semibold">Medium (Default)</h3>
+            <g-link size="md" href="https://empresas.global66.com/" icon-right="regular chevron-right">Medium link</g-link>
+          </div>
+          
+          <div>
+            <h3 class="mb-2 font-semibold">Large</h3>
+            <g-link size="lg" href="https://empresas.global66.com/" icon-right="regular chevron-right">Large link</g-link>
+          </div>
+          
+          <div>
+            <h3 class="mb-2 font-semibold">Todos los tamaños con íconos</h3>
+            <div class="flex flex-col gap-4 items-start">
+              <g-link size="sm" href="https://empresas.global66.com/" icon-left="regular link" icon-right="regular chevron-right">Small link</g-link>
+              <g-link size="md" href="https://empresas.global66.com/" icon-left="regular link" icon-right="regular chevron-right">Medium link</g-link>
+              <g-link size="lg" href="https://empresas.global66.com/" icon-left="regular link" icon-right="regular chevron-right">Large link</g-link>
+            </div>
+          </div>
+        </div>
+      </g-config-provider>
+    `,
+  }),
+  parameters: {
+    docs: {
+      description: {
+        story: "links en diferentes tamaños: pequeño (sm), mediano (md) y grande (lg)."
+      },
+      source: {
+        code: `
+<g-link size="sm" href="https://empresas.global66.com/">link pequeño</g-link>
+
+<g-link size="md" href="https://empresas.global66.com/">link mediano</g-link>
+
+<g-link size="lg" href="https://empresas.global66.com/">link grande</g-link>`,
+        language: "html",
+        type: "auto",
+      },
+    },
+  },
+};
+
+export const Types: Story = {
+  name: 'Tipos de link',
+  render: () => ({
+    components: { GLink, GConfigProvider },
+    template: `
+      <g-config-provider>
+        <div class="flex flex-col space-y-4">
+          <div>
+            <h3 class="mb-2 font-semibold">Default</h3>
+            <g-link type="default" href="https://empresas.global66.com/">Link por defecto</g-link>
+          </div>
+          
+          <div>
+            <h3 class="mb-2 font-semibold">Underline</h3>
+            <g-link type="underline" href="https://empresas.global66.com/">Link underline</g-link>
+          </div>
+          
+          <div>
+            <h3 class="mb-2 font-semibold">Primary</h3>
+            <g-link type="primary" href="https://empresas.global66.com/">Link primario</g-link>
+          </div>
+          
+          <div>
+            <h3 class="mb-2 font-semibold">Success</h3>
+            <g-link type="success" href="https://empresas.global66.com/">Link de éxito</g-link>
+          </div>
+          
+          <div>
+            <h3 class="mb-2 font-semibold">Warning</h3>
+            <g-link type="warning" href="https://empresas.global66.com/">Link de advertencia</g-link>
+          </div>
+          
+          <div>
+            <h3 class="mb-2 font-semibold">Danger</h3>
+            <g-link type="danger" href="https://empresas.global66.com/">Link de peligro</g-link>
+          </div>
+          
+          <div>
+            <h3 class="mb-2 font-semibold">Info</h3>
+            <g-link type="info" href="https://empresas.global66.com/">Link informativo</g-link>
+          </div>
+        </div>
+      </g-config-provider>
+    `,
+  }),
+  parameters: {
+    docs: {
+      description: {
+        story: "links con diferentes tipos de estilo: default, underline, primary, success, warning, danger e info."
+      },
+      source: {
+        code: `
+<g-link type="default" href="https://empresas.global66.com/">Link por defecto</g-link>
+
+<g-link type="underline" href="https://empresas.global66.com/">Link underline</g-link>
+
+<g-link type="primary" href="https://empresas.global66.com/">Link primario</g-link>
+
+<g-link type="success" href="https://empresas.global66.com/">Link de éxito</g-link>
+
+<g-link type="warning" href="https://empresas.global66.com/">Link de advertencia</g-link>
+
+<g-link type="danger" href="https://empresas.global66.com/">Link de peligro</g-link>
+
+<g-link type="info" href="https://empresas.global66.com/">Link informativo</g-link>`,
+        language: "html",
+        type: "auto",
+      },
+    },
+  },
+};
+
+export const DisabledState: Story = {
+  name: 'Link deshabilitado',
+  args: {
+    disabled: true,
+    default: 'link deshabilitado',
+    iconRight: 'regular chevron-right',
+  },
+  render: (args) => ({
+    components: { GLink, GConfigProvider },
+    setup() {
+      return { args };
+    },
+    template: `
+      <g-config-provider>
+        <g-link v-bind="args">{{ args.default }}</g-link>
+      </g-config-provider>
+    `,
+  }),
+  parameters: {
+    docs: {
+      description: {
+        story: "links en estado deshabilitado que no permiten interacción."
+      },
+      source: {
+        code: `
+<g-link disabled href="https://empresas.global66.com/">link deshabilitado</g-link>
+
+<g-link disabled icon-right="regular chevron-right" href="https://empresas.global66.com/">
+  link deshabilitado con ícono
+</g-link>`,
+        language: "html",
+        type: "auto",
+      },
+    },
+  },
+};
+
+export const ExternalLinks: Story = {
+  name: 'Links externos',
+  render: () => ({
+    components: { GLink, GConfigProvider },
+    template: `
+      <g-config-provider>
+        <div class="flex flex-col space-y-4 items-start">
+          <g-link href="https://empresas.global66.com/" target="_blank" icon-right="regular arrow-up-right-from-square">
+            Abre en nueva pestaña
+          </g-link>
+          <g-link href="https://empresas.global66.com/" target="_self">
+            Abre en la misma pestaña
+          </g-link>
+        </div>
+      </g-config-provider>
+    `,
+  }),
+  parameters: {
+    docs: {
+      description: {
+        story: "links que apuntan a sitios externos, con diferentes configuraciones del atributo target."
+      },
+      source: {
+        code: `
+<g-link href="https://empresas.global66.com/" target="_blank" icon-right="regular arrow-up-right-from-square">
+  Abre en nueva pestaña
+</g-link>
+
+<g-link href="https://empresas.global66.com/" target="_self">
+  Abre en la misma pestaña
+</g-link>`,
+        language: "html",
+        type: "auto",
+      },
+    },
+  },
+};
+
+export const LinkStatus: Story = {
+  name: 'Estados del link',
+  render: () => ({
+    components: { GLink, GConfigProvider },
+    template: `
+      <g-config-provider>
+        <div class="flex flex-col space-y-4">
+          <div>
+            <h3 class="mb-2 font-semibold">Default Status</h3>
+            <g-link status="default" href="https://empresas.global66.com/">Link con status default</g-link>
+          </div>
+          
+          <div>
+            <h3 class="mb-2 font-semibold">Inline Status</h3>
+            <p class="mb-2">Este es un ejemplo de un párrafo con un <g-link status="inline" href="https://empresas.global66.com/">link inline</g-link> que está integrado dentro del texto.</p>
+          </div>
+        </div>
+      </g-config-provider>
+    `,
+  }),
+  parameters: {
+    docs: {
+      description: {
+        story: "Links con diferentes estados: default (enlaces independientes) e inline (enlaces dentro de texto)."
+      },
+      source: {
+        code: `
+<!-- Status: Default -->
+<g-link status="default" href="https://empresas.global66.com/">Link con status default</g-link>
+
+<!-- Status: Inline (para enlaces dentro de texto) -->
+<p>Este es un ejemplo de un párrafo con un <g-link status="inline" href="https://empresas.global66.com/">link inline</g-link> que está integrado dentro del texto.</p>`,
+        language: "html",
+        type: "auto",
+      },
+    },
+  },
+};


### PR DESCRIPTION
Link component
• Link.vue (component implementation)
• link.styles.scss (styling),
• link.ts (props/emits definitions)
• index.ts (component export).  
The component supports icons, different states (disabled, underline), and various style customizations.